### PR TITLE
Fix: 퀴즈의 댓글 상세보기 api추가, members.router.js 내용 누락 수정

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ import express from "express";
 import QuizzersRouter from "./src/routes/quizzes.router.js";
 import membersRouter from "./src/routes/members.router.js";
 import DebatesRouter from "./src/routes/debates.router.js";
+import QuizzCommentsRouter from "./src/routes/quizcomments.router.js";
 import errorHandlingMiddleware from "./src/middlewares/error.handling.middleware.js";
 import cookieParser from "cookie-parser";
 import expressSession from "express-session";
@@ -44,7 +45,7 @@ router.get("/", (req, res) => {
   return res.json({ message: "hello world" });
 });
 
-app.use("/api", [QuizzersRouter, membersRouter, DebatesRouter]);
+app.use("/api", [QuizzersRouter, membersRouter, DebatesRouter, QuizzCommentsRouter]);
 app.use(errorHandlingMiddleware);
 
 app.listen(port, () => {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Quizzes {
     updatedAt          DateTime    @updatedAt
     deletedAt          DateTime?  
     User               Members     @relation(fields: [UserId], references: [userId])
+    quizComments       QuizComments[]
 
     @@map("Quizzes")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ model Members {
     quizzes            Quizzes[]
     debates            Debates[] 
     comments           Comments[]
-    quizComments       QuizComments[] // 새로추가. 기능사용하지않을시 주석처리
+    quizComments       QuizComments[] 
     @@map("Members")
 }
 
@@ -67,7 +67,6 @@ model Comments {
   @@map("Comments")
 }
 
-// 퀴즈 게시판의 댓글 등록을 할때 필요한 테이블. 사용하지 않으면 주석처리
 model QuizComments {
   quizCommentId       Int          @id @default(autoincrement)
   QuizId              Int
@@ -79,7 +78,6 @@ model QuizComments {
 
   User                Members      @relation(fields: [UserId], references: [userId])
   Quiz                Quizzes      @relation(fields: [QuizId], references: [quizId], onDelete: Cascade)
-
 
   @@map("QuizComments")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,7 +69,7 @@ model Comments {
 }
 
 model QuizComments {
-  quizCommentId       Int          @id @default(autoincrement)
+  quizCommentId       Int          @id @default(autoincrement())
   QuizId              Int
   UserId              Int
   content             String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Members {
     quizzes            Quizzes[]
     debates            Debates[] 
     comments           Comments[]
+    quizComments       QuizComments[] // 새로추가. 기능사용하지않을시 주석처리
     @@map("Members")
 }
 
@@ -66,3 +67,19 @@ model Comments {
   @@map("Comments")
 }
 
+// 퀴즈 게시판의 댓글 등록을 할때 필요한 테이블. 사용하지 않으면 주석처리
+model QuizComments {
+  quizCommentId       Int          @id @default(autoincrement)
+  QuizId              Int
+  UserId              Int
+  content             String
+  createdAt           DateTime     @default(now())
+  updatedAt           DateTime     @updatedAt
+  deletedAt           DateTime?
+
+  User                Members      @relation(fields: [UserId], references: [userId])
+  Quiz                Quizzes      @relation(fields: [QuizId], references: [quizId], onDelete: Cascade)
+
+
+  @@map("QuizComments")
+}

--- a/src/routes/members.router.js
+++ b/src/routes/members.router.js
@@ -1,162 +1,183 @@
 import express from "express";
-import upload from '../../assets/AWS.S3.js'
-import memberMiddleware from "../middlewares/member.middleware.js";
-import { prisma } from "../utils/index.js";
 import Joi from "joi";
+import * as bcrypt from "bcrypt";
+import jwt from "jsonwebtoken";
+import { prisma } from "../utils/index.js";
+import memberMiddleware from "../middlewares/member.middleware.js";
 
-const router = express.Router();
+const membersRouter = express.Router();
 
-// 유효성 검사 추가함.
-const checkQuizzes = Joi.object({
-    title: Joi.string().min(2).max(30),
-    content: Joi.string().min(5)
-})
+// 아이디 유효성 검사 부분.
+const memberSchema = Joi.object({
+    username: Joi.string().pattern(new RegExp("^[a-zA-Z0-9]{2,15}$")).required(),
+    nickname: Joi.string().min(2).max(15).required(),
+    password: Joi.string().pattern(new RegExp("^[a-zA-Z0-9]{5,20}$")).required(),
+});
 
-// 퀴즈 등록 api
-router.post('/quizzes', upload.single('image'), memberMiddleware, async (req, res, next) => {
+// 회원 가입 API
+membersRouter.post("/sign-up", async (req, res, next) => {
     try {
-        const { title, content } = await checkQuizzes.validateAsync(req.body)
-        if (!title || !content) throw { name: "ValidationError" } // 추가함.
-        // memberMiddleware 를 통해 설정된 req.member 에서 사용자 정보를 가져오기
-        const member = req.member;
-        // 업로드된 이미지 파일의 위치를 요청 본문의 image 필드에 할당
-        req.body.image = req.file.location;
-        // prisma를 사용하여 퀴즈를 db에 저장
-        const quiz = await prisma.quizzes.create({
+        // 여기서 유효성 검사.
+        const { username, nickname, password } = await memberSchema.validateAsync(
+            req.body
+        );
+        // 에러 처리 부분.
+        if (password.includes(username)) throw { name: "Duplication" };
+        if (!nickname || !password || !username) throw { name: "ValidationError" };
+        const isExistMember = await prisma.Members.findFirst({
+            where: { username },
+        })
+        if (isExistMember) throw { name: "ExistMember" };
+        const isExistNickName = await prisma.Members.findFirst({
+            where: { nickname },
+        });
+        if (isExistNickName) throw { name: "ExistNickName" };
+
+        const salt = bcrypt.genSaltSync(parseInt(process.env.BCRYPT_SALT));
+        const hash_password = bcrypt.hashSync(password, salt);
+
+        // 여기서 최종적으로 디비에 저장.
+        const member = await prisma.Members.create({
             data: {
-                UserId: member.userId,
-                title,
-                content,
-                imageURL: req.file.location,
-            }
+                username,
+                nickname,
+                password: hash_password,
+            },
         });
-        return res.status(200).json({ message: "퀴즈를 등록하였습니다.", data: quiz });
+        return res
+            .status(200)
+            .json({ message: " 회원 가입이 완료 되었습니다. ", data: member });
     } catch (err) {
-        next(err) // 수정
+        next(err);
     }
 });
 
-// 퀴즈 수정 api
-router.patch('/quizzes/:quizId', upload.single('image'), memberMiddleware, async (req, res, next) => {
+// 로그인 API
+membersRouter.post("/sign-in", async (req, res, next) => {
     try {
-        const { title, content } = await checkQuizzes.validateAsync(req.body) // body로부터 수정된 title과 content을 받음
-        const { quizId } = req.params; // URL에서 quizId를 추출
+        const { username, password } = req.body;
 
-        // 수정하기 위한 필수 데이터 체크
-        if (!quizId) throw { name: "ValidationError" } // 수정
+        // 에러 처리 부분.
+        if (!username || !password) throw { name: "ValidationError" };
 
-        // 게시된 퀴즈가 있는지 존재 여부를 확인
-        let quiz = await prisma.quizzes.findUnique({
-            where: { quizId: +quizId },
-        });
-        if (!quiz) throw { name: "NoneData" } // 수정
+        const member = await prisma.Members.findFirst({ where: { username } });
+        if (!member) throw { name: "NoneData" }
 
-        // 퀴즈 수정을 위한 데이터 준비
-        const updateQuiz = {
-            title: title || quiz.title, // 새로운 제목을 입력하면 사용하고, 그렇지 않다면 이전 제목을 유지
-            content: content || quiz.content, // 새로운 내용을 입력하면 사용하고, 그렇지 않다면 이전 내용을 유지
-            imageURL: req.file ? req.file.location : quiz.imageURL, // 새로운 이미지로 변경하면 사용하고, 그렇지 않다면 이전 이미지를 유지
-        };
-
-        // 퀴즈를 업데이트
-        quiz = await prisma.quizzes.update({
-            where: { quizId: +quizId },
-            data: updateQuiz,
-        });
-
-        // 클라이언트에게 응답
-        return res.status(200).json({ message: "퀴즈를 수정하였습니다.", data: quiz });
-
-    } catch (err) {
-        next(err) // 수정
-    }
-});
-
-// 퀴즈 삭제 api
-router.delete('/quizzes/:quizId', memberMiddleware, async (req, res) => {
-    try {
-        const { quizId } = req.params; // params로부터 삭제할 quizId를 받습니다.
-
-        // URL에서 추출한 quizId를 이용하여 퀴즈를 찾습니다.
-        const quiz = await prisma.quizzes.findUnique({
-            where: { quizId: +quizId },
-        });
-
-        // 해당 quizId에 해당하는 퀴즈가 없는 경우 404 에러를 반환합니다.
-        if (!quiz) throw { name: "NoneData" } // 추가.
-
-        // 이미 삭제된 퀴즈인 경우에는 이미 삭제되었다고 응답합니다.
-        if (quiz.deletedAt !== null) {
-            return res.status(200).json({ message: "퀴즈가 이미 삭제되었습니다." });
+        if (username !== member.username) throw { name: "nameError" };
+        // 해쉬화 된 비밀번호 일치 하는지 확인.
+        const checkPassword = await bcrypt.compare(password, member.password);
+        if (!checkPassword) {
+            return res
+                .status(400)
+                .json({ errorMessage: " 비밀번호가 일치 하지 않습니다. " });
         }
 
-        // 소프트 삭제를 위해 deletedAt 필드를 현재 시간으로 업데이트합니다.
-        const softDeletedQuiz = await prisma.quizzes.update({
-            where: { quizId: +quizId },
-            data: { deletedAt: new Date() },
+        const accessToken = createAccessToken(member.username);
+
+        const refreshToken = createRefreshToken(member.username);
+
+        const salt = bcrypt.genSaltSync(parseInt(process.env.BCRYPT_SALT));
+        const hashedRefreshToken = bcrypt.hashSync(refreshToken, salt);
+
+        await prisma.Members.update({
+            where: { userId: member.userId },
+            data: {
+                hashedRefreshToken,
+            },
         });
 
-        // 클라이언트에게 응답합니다.
-        return res.status(200).json({ message: "퀴즈를 삭제하였습니다.", data: softDeletedQuiz });
+        // name accesstoken
+        // name refreshtoken
+        res.cookie("accessToken", `Bearer ${accessToken}`, {
+            secure: true,
+        });
+        res.cookie("refreshToken", `Bearer ${refreshToken}`, {
+            secure: true,
+        });
+
+        return res.status(200).json({ message: "로그인 성공." });
     } catch (err) {
-        next(err) // 수정
+        next(err);
     }
 });
 
-// 퀴즈 목록 api
-router.get('/quizzes', memberMiddleware, async (req, res, next) => {
+// 로그아웃 API
+membersRouter.post("/sign-out", memberMiddleware, async (req, res, next) => {
     try {
-        // prisma를 사용하여 등록된 퀴즈 목록을 가져오기
-        // 퀴즈를 찾을건데 = prisma의 quizzes에서, 다수의 퀴즈를 찾을거야.
-        const quizzes = await prisma.quizzes.findMany({
-            where: { // 어디서 갖고올건데? ('어떤 조건을 가진' 퀴즈가 속한 위치를 정할거야.)
-                deletedAt: null, //소프트 삭제되지 않은 퀴즈만 조회
-            },
-            select: { // 내가 가져올 퀴즈의 필드
-                quizId: true,
-                title: true,
-                imageURL: true,
-                content: true,
+        if (!req.member) throw { name: "NoneData" };
+        res.clearCookie("accessToken");
+        res.clearCookie("refreshToken");
+
+        await prisma.Members.update({
+            where: { userId: req.member.userId },
+            data: {
+                hashedRefreshToken: null,
             },
         });
-        // 클라이언트에게 찾은 퀴즈목록을 보여줍니다.
-        return res.status(200).json({ data: quizzes });
+        return res.status(200).json({ message: "로그아웃." });
     } catch (err) {
-        next(err)
+        next(err);
     }
 });
 
-// 목록에서 선택한 퀴즈의 상세보기 api
-router.get('/quizzes/:quizId', memberMiddleware, async (req, res, next) => {
+// 비밀번호 변경 API
+// 비밀번호 바디에 받고 -> 확인
+// 맞으면 변경.
+membersRouter.patch("/pwupdate", memberMiddleware, async (req, res, next) => {
     try {
-        const { quizId } = req.params;
-        const quiz = await prisma.Quizzes.findUnique({
-            where: {
-                quizId: +quizId, deletedAt: null // 추출한 상세보기하려는 퀴즈의 주소값을 정수화합니다.
-            },
-            select: {
-                title: true,
-                imageURL: true,
-                content: true,
-            }
+        if (!req.member) throw { name: "NoneData" };
+        const { password, newPassword } = req.body;
+
+        console.log(password, newPassword);
+
+        const findUser = await prisma.Members.findFirst({
+            where: { username: req.member.username },
         });
-        // 해당 id의 퀴즈가 없다면?
-        if (!quiz) throw { name: "NoneData" } // 수정.
-        // 퀴즈를 상세보기합니다.
-        return res.status(200).json(quiz);
+
+        const checkPassword = await bcrypt.compare(password, findUser.password);
+        if (!checkPassword) {
+            return res
+                .status(400)
+                .json({ errorMessage: " 비밀번호가 일치 하지 않습니다. " });
+        }
+
+        const salt = bcrypt.genSaltSync(parseInt(process.env.BCRYPT_SALT));
+
+        const hashPassword = bcrypt.hashSync(newPassword, salt);
+
+        console.log(hashPassword);
+
+        await prisma.Members.update({
+            where: { userId: findUser.userId },
+            data: {
+                password: hashPassword,
+            },
+        });
+        return res.status(200).json({ message: " 비밀번호가 변경 되었습니다. " });
     } catch (err) {
-        next(err)
+        next(err);
     }
 });
 
-// 상세보기 했을 때 해당 퀴즈의 삭제 api
+export function createAccessToken(username) {
+    const accessToken = jwt.sign(
+        { username }, // JWT 데이터
+        process.env.JWT_ACCESS_SECRET_KEY, // Access Token의 비밀 키
+        { expiresIn: "1h" } // Access Token이 10초 뒤에 만료되도록 설정.
+    );
 
+    return accessToken;
+}
 
+// Refresh Token을 생성하는 함수
+export function createRefreshToken(username) {
+    const refreshToken = jwt.sign(
+        { username }, // JWT 데이터
+        process.env.JWT_REFRESH_SECRET_KEY, // Refresh Token의 비밀 키
+        { expiresIn: "7d" } // Refresh Token이 7일 뒤에 만료되도록 설정.
+    );
 
-export default router;
+    return refreshToken;
+}
 
-
-// 작성v, 수정v, 삭제v, 상세보기v, 목록v,
-
-// 작성 post, 수정 patch, 삭제 deletd, 상세보기 get, 목록 get 
-
+export default membersRouter;

--- a/src/routes/members.router.js
+++ b/src/routes/members.router.js
@@ -16,22 +16,22 @@ const memberSchema = Joi.object({
 
 // 회원 가입 API
 membersRouter.post("/sign-up", async (req, res, next) => {
-  try {
-    // 여기서 유효성 검사.
-    const { username, nickname, password } = await memberSchema.validateAsync(
-      req.body
-    );
-    // 에러 처리 부분.
-    if (password.includes(username)) throw { name: "Duplication" };
-    if (!nickname || !password || !username) throw { name: "ValidationError" };
-    const isExistMember = await prisma.Members.findFirst({
-      where: { username },
-    })
-    if (isExistMember) throw { name: "ExistMember" };
-    const isExistNickName = await prisma.Members.findFirst({
-      where: { nickname },
-    });
-    if (isExistNickName) throw { name: "ExistNickName" };
+    try {
+        // 여기서 유효성 검사.
+        const { username, nickname, password } = await memberSchema.validateAsync(
+            req.body
+        );
+        // 에러 처리 부분.
+        if (password.includes(username)) throw { name: "Duplication" };
+        if (!nickname || !password || !username) throw { name: "ValidationError" };
+        const isExistMember = await prisma.Members.findFirst({
+            where: { username },
+        })
+        if (isExistMember) throw { name: "ExistMember" };
+        const isExistNickName = await prisma.Members.findFirst({
+            where: { nickname },
+        });
+        if (isExistNickName) throw { name: "ExistNickName" };
 
         const salt = bcrypt.genSaltSync(parseInt(process.env.BCRYPT_SALT));
         const hash_password = bcrypt.hashSync(password, salt);
@@ -60,8 +60,8 @@ membersRouter.post("/sign-in", async (req, res, next) => {
         // 에러 처리 부분.
         if (!username || !password) throw { name: "ValidationError" };
 
-    const member = await prisma.Members.findFirst({ where: { username } });
-    if (!member) throw { name: "NoneData" }
+        const member = await prisma.Members.findFirst({ where: { username } });
+        if (!member) throw { name: "NoneData" }
 
         if (username !== member.username) throw { name: "nameError" };
         // 해쉬화 된 비밀번호 일치 하는지 확인.

--- a/src/routes/quizcomments.router.js
+++ b/src/routes/quizcomments.router.js
@@ -1,0 +1,57 @@
+import express from "express";
+// import upload from '../../assets/AWS.S3.js'
+import memberMiddleware from "../middlewares/member.middleware.js";
+import { prisma } from "../utils/index.js";
+import Joi from "joi";
+
+const router = express.Router();
+
+// 유효성 검사 추가함.
+const checkComments = Joi.object({
+    content: Joi.string().min(1) // 댓글을 달려면 최소 1글자 이상 입력해야 합니다.
+})
+
+// 퀴즈 게시물의 댓글 등록 api
+router.post('/quizzes/:quizId/quizComments', memberMiddleware, async (req, res, next) => {
+    try {
+        // 로그인 된 사용자ID
+        const userId = req.member.userId;
+
+        // 퀴즈id, 댓글 내용을 요청에서 받아옵니다.
+        const { quizId } = req.params;
+        // const { content } = req.body;
+
+        // 유효성 검사
+        const { content } = await checkComments.validateAsync(req.body)
+
+        // 그 퀴즈 게시물이 존재하는가?
+        const existingQuiz = await prisma.quizzes.findUnique({ where: { quizId: +quizId } });
+        if (!existingQuiz) { return res.status(404).json({ message: "퀴즈를 찾을 수 없습니다." }) };
+
+        // 퀴즈에 댓글을 등록
+        const newComment = await prisma.quizComments.create({ data: { QuizId: +quizId, UserId: userId, content } });
+
+        return res.status(201).json({ message: "댓글이 등록되었습니다.", data: newComment });
+
+    } catch (error) {next(error);}
+});
+
+//  퀴즈 게시물의 댓글 목록 api
+router.get('/quizzes/:quizId/quizComments', memberMiddleware, async (req, res, next) => {
+    try {
+        const { quizId } = req.params;
+        const comments = await prisma.quizComments.findMany({
+            where: {
+                QuizId: +quizId,
+            }
+            // 댓글목록 불러올 때 댓글 작성자의 정보를 불러옵니다. 이 부분은 이용자 입장에서 쓸모없으므로 주석처리
+            // include: {
+            //     User: true, 
+            // }
+        });
+
+        return res.status(200).json({ comments });
+    } catch (error) {next(error)};
+});
+
+export default router;

--- a/src/routes/quizzes.router.js
+++ b/src/routes/quizzes.router.js
@@ -16,7 +16,7 @@ const checkQuizzes = Joi.object({
 router.post('/quizzes', upload.single('image'), memberMiddleware, async (req, res, next) => {
     try {
         const { title, content } = await checkQuizzes.validateAsync(req.body)
-        if(!title || !content) throw { name: "ValidationError" } // 추가함.
+        if (!title || !content) throw { name: "ValidationError" } // 추가함.
         // memberMiddleware 를 통해 설정된 req.member 에서 사용자 정보를 가져오기
         const member = req.member;
         // 업로드된 이미지 파일의 위치를 요청 본문의 image 필드에 할당
@@ -129,7 +129,7 @@ router.get('/quizzes', memberMiddleware, async (req, res, next) => {
 // 목록에서 선택한 퀴즈의 상세보기 api
 router.get('/quizzes/:quizId', memberMiddleware, async (req, res, next) => {
     try {
-        const { quizId } = req.params; 
+        const { quizId } = req.params;
         const quiz = await prisma.Quizzes.findUnique({
             where: {
                 quizId: +quizId, deletedAt: null // 추출한 상세보기하려는 퀴즈의 주소값을 정수화합니다.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@colors/colors@^1.6.0", "@colors/colors@1.6.0":
+"@colors/colors@1.6.0", "@colors/colors@^1.6.0":
   version "1.6.0"
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz"
   integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
@@ -305,15 +305,15 @@ color-convert@^1.9.3:
   dependencies:
     color-name "1.1.3"
 
-color-name@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-string@^1.6.0:
   version "1.9.1"
@@ -409,14 +409,13 @@ core-util-is@~1.0.0:
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-
-debug@^4:
-  version "4.3.4"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
   dependencies:
-    ms "2.1.2"
-
+    object-assign "^4"
+    vary "^1"
 
 debug@2.6.9:
   version "2.6.9"
@@ -425,7 +424,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4:
+debug@4, debug@^4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -446,7 +445,7 @@ delegates@^1.0.0:
   resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
-depd@~2.0.0, depd@2.0.0:
+depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
@@ -616,6 +615,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -737,15 +741,15 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 ieee754@1.1.13:
   version "1.1.13"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.4:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore-by-default@^1.0.1:
   version "1.0.1"
@@ -760,7 +764,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@~2.0.3, inherits@2, inherits@2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1005,11 +1009,6 @@ mkdirp@^1.0.3:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-ms@^2.1.1, ms@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
@@ -1019,6 +1018,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@2.1.3, ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multer-s3@2.10.0:
   version "2.10.0"
@@ -1165,7 +1169,7 @@ prettier@^3.1.1:
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz"
   integrity sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==
 
-prisma@*, prisma@^5.7.1:
+prisma@^5.7.1:
   version "5.8.0"
   resolved "https://registry.npmjs.org/prisma/-/prisma-5.8.0.tgz"
   integrity sha512-hDKoEqPt2qEUTH5yGO3l27CBnPtwvte0CGMKrpCr9+/A919JghfqJ3qgCGgMbOwdkXUOzdho0RH9tyUF3UhpMw==
@@ -1275,7 +1279,7 @@ run-parallel@^1.1.6:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -1295,15 +1299,15 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sax@>=0.6.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz"
-  integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
-
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
   integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
+
+sax@>=0.6.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz"
+  integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
 
 semver@^6.0.0:
   version "6.3.1"
@@ -1409,6 +1413,15 @@ streamsearch@^1.1.0:
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
@@ -1422,15 +1435,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 strip-ansi@^6.0.1:
   version "6.0.1"
@@ -1517,7 +1521,7 @@ undefsafe@^2.0.5:
   resolved "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
-unpipe@~1.0.0, unpipe@1.0.0:
+unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
@@ -1540,19 +1544,17 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
-
-
 uuid4@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/uuid4/-/uuid4-2.0.3.tgz"
   integrity sha512-CTpAkEVXMNJl2ojgtpLXHgz23dh8z81u6/HEPiQFOvBc/c2pde6TVHmH4uwY0d/GLF3tb7+VDAj4+2eJaQSdZQ==
 
-vary@~1.1.2:
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==


### PR DESCRIPTION
추가된 라우터 -> quizcomments.router.js
등록된 퀴즈에 댓글을 등록할 수 있는 라우터입니다.

동봉된 api로는 퀴즈의 댓글 등록 api, 그리고 퀴즈에 등록된 댓글 목록 api가 있습니다.

또한, quizzes 브랜치에 members.router.js의 내용이 quzzies.router.js 내용으로 변경되어 작동하지 않는 상황이 있어, 이 내용을 수정하였습니다.